### PR TITLE
Revert "SHOP-1388: bump @youcan packages to latest (2.6.5)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@prisma/client": "5.7.0",
     "@youcan/qantra": "latest",
-    "@youcan/ui-core": "2.6.5",
-    "@youcan/ui-icons": "2.6.5",
-    "@youcan/ui-vue3": "2.6.5",
+    "@youcan/ui-core": "2.5.9-beta.1",
+    "@youcan/ui-icons": "2.5.9-beta.1",
+    "@youcan/ui-vue3": "2.5.9-beta.1",
     "isbot": "^4.2.0",
     "jsonwebtoken": "^9.0.2"
   }


### PR DESCRIPTION
Reverts youcan-shop/shop-app-template-nuxt#4 Because RichText component was introduced in 2.6.0 which breaks Nuxt for some SSR reason. Reverting until a fix is complete: https://youcanshop.atlassian.net/browse/UI-370